### PR TITLE
added template input to frontmatter.mmd

### DIFF
--- a/frontmatter.mmd
+++ b/frontmatter.mmd
@@ -10,3 +10,5 @@ my fixed: $MYFIXED
 my email: $MYEMAIL
 my linkedin: $MYLINKEDIN
 my github: $MYGITHUB
+latex input: $TEMPLATE/setup.tex
+latex footer: $TEMPLATE/footer.tex


### PR DESCRIPTION
Previously, upon creating executing `scriptorium new -t resume Res-Fix-Test`, defining the proper variables, and executing `scriptorium build Res-Fix-Test` yielded `OSError: no obvious root`.
Executing `scriptorium build Res-Fix-Test/resume.mmd` yielded `OSError: resume.mmd does not appear to have lines necessary to load a template`.

This commit fixes those errors (tested locally on my machine)